### PR TITLE
Dummy transition support, rapidprom, many fixes

### DIFF
--- a/pmlab/log/reencoders.py
+++ b/pmlab/log/reencoders.py
@@ -1,14 +1,6 @@
-import pickle
 """Provides some custom reencoders for the pmlab package."""
+import pickle
 
-#def reencode_for_stp(word):
-#    """Identifiers cannot contain blanks nor underscores (since they interfere
-#    with the variable naming scheme)"""
-#    return word.translate(None,' \t_')
-
-#def alpha_reencoder(word):
-#    #use generators? yield
-#    return
 class NonInvertibleDictionaryError(Exception): pass
 
 def reencoder_from_file(filename):
@@ -73,24 +65,25 @@ class DictionaryReencoder():
         return DictionaryReencoder(inv_dict)
 
 class AlphaReencoder(DictionaryReencoder):
+    """Rencodes by transforming event names into a, b, c, ...
+    If more than 27 event names exist, then it uses a, b, ..., aa, ab, ... is used."""
     def update_dictionary(self, word):
-        #to be reimplemented in subclasses
-        self.dict[word] = chr(ord('a')+len(self.dict))
+        base_letter = ord('a')
+        num_letters = 1 + ord('z') - ord('a')
+        n = len(self.dict) + 1
+        name = ''
+        while n > 0:
+            name = chr(base_letter + ((n - 1) % num_letters)) + name
+            n = ((n - 1) / num_letters)
 
-#we cannot use global instance variables because they keep dictionary state
-#between calls!!!
-#alpha_reencoder = AlphaReencoder()
+        self.dict[word] = name
 
 class EventNumberReencoder(DictionaryReencoder):
+	"""Reencodes by transforming event names into e0, e1, e2, ..."""
     def update_dictionary(self, word):
-        #to be reimplemented in subclasses
         self.dict[word] = 'e{0}'.format(len(self.dict))
-
-#event_number_reencoder = EventNumberReencoder()
 
 class StpReencoder(DictionaryReencoder):
     def update_dictionary(self, word):
-        #to be reimplemented in subclasses
         self.dict[word] = word.translate(None," '.\t_()-+&")
 
-#stp_reencoder = StpReencoder()

--- a/pmlab/log/reencoders.py
+++ b/pmlab/log/reencoders.py
@@ -79,7 +79,7 @@ class AlphaReencoder(DictionaryReencoder):
         self.dict[word] = name
 
 class EventNumberReencoder(DictionaryReencoder):
-	"""Reencodes by transforming event names into e0, e1, e2, ..."""
+    """Reencodes by transforming event names into e0, e1, e2, ..."""
     def update_dictionary(self, word):
         self.dict[word] = 'e{0}'.format(len(self.dict))
 

--- a/pmlab/log_ts/__init__.py
+++ b/pmlab/log_ts/__init__.py
@@ -1,12 +1,14 @@
 from .. log import Log
 from .. ts import TransitionSystem, IndeterminedTsError
 
-def cases_included_in_ts(log, ts, uniq_cases=False):
-    """Returns a log containing only the cases (and parts of cases) that fit 
-    in the TS. Prints information on how the cases of a log can be reproduced by
+def cases_included_in_ts(log, ts, uniq_cases=False, partial_cases=False, verbose=False):
+    """Returns a log containing only the cases (and optionally parts of cases) that fit
+    in the TS.
+    [uniq_cases] If True, consider only unique cases.
+    [partial_cases] If True, consider also cases that are only partially covered.
+    [verbose] If True, prints information on how the cases of a log can be reproduced by
     a TS or not.
-    
-    [uniq_cases] If True, consider only unique cases."""
+    """
     partially_included=0
     totally_included=0
     excluded_traces=0
@@ -36,22 +38,24 @@ def cases_included_in_ts(log, ts, uniq_cases=False):
         else:
             ratio += i/((1.0)*len(case))*occ
             partially_included += occ
-        if i != 0:
+        if i == len(case) or (partial_cases and i > 0):
             saved_cases[tuple(case[:i])] = occ
-    num_cases = len(cases)
-    width=len(str(num_cases))
-    print "Total cases in log:  {0:{width}}".format(num_cases, width=width)
-    print "Excluded:            {0:{width}} {1:7.2%}".format(excluded_traces, 
-                                                            excluded_traces / (1.0*num_cases),
-                                                            width=width )
-    print "Partially Included:  {0:{width}} {1:7.2%}".format(partially_included, 
-                                                partially_included / (1.0*num_cases),
-                                                width=width),
-    if partially_included:
-        print "average included length {0:5.2%}".format(ratio/(1.0*partially_included))
-    else:
-        print
-    print "Totally Included:    {0:{width}} {1:7.2%}".format(totally_included, 
-                                                            totally_included / (1.0*num_cases),
-                                                            width=width )
+
+    if verbose:
+        num_cases = len(cases)
+        width=len(str(num_cases))
+        print "Total cases in log:  {0:{width}}".format(num_cases, width=width)
+        print "Excluded:            {0:{width}} {1:7.2%}".format(excluded_traces,
+                                                                excluded_traces / (1.0*num_cases),
+                                                                width=width )
+        print "Partially Included:  {0:{width}} {1:7.2%}".format(partially_included,
+                                                    partially_included / (1.0*num_cases),
+                                                    width=width),
+        if partially_included:
+            print "average included length {0:5.2%}".format(ratio/(1.0*partially_included))
+        else:
+            print
+        print "Totally Included:    {0:{width}} {1:7.2%}".format(totally_included,
+                                                                totally_included / (1.0*num_cases),
+                                                                width=width )
     return Log(uniq_cases=saved_cases)

--- a/pmlab/pn/__init__.py
+++ b/pmlab/pn/__init__.py
@@ -8,7 +8,7 @@ from pyparsing import (ParserElement, Word, Optional, Literal, oneOf, LineEnd,
                         alphas, nums, alphanums, pythonStyleComment)
 import graph_tool.all as gt
 import xml.etree.ElementTree as xmltree
-from .. ts import ts_from_sis, draw_astg
+from .. ts import ts_from_sis
 
 __all__ = ['pn_from_ts', 'ts_from_pn', 'pn_from_file', 'PetriNet']
 

--- a/pmlab/pn/bound.py
+++ b/pmlab/pn/bound.py
@@ -1,0 +1,41 @@
+# TODO Handle arcs with multiplicity > 1
+
+def bound(pn):
+    """Artificially creates new places in [pn] which ensure that every
+    preexisting place will never contain more tokens than its capacity,
+    even if the original [pn] is unbounded.
+    This function does not do any intelligent analysis; the returned net will
+    have twice the number of places of the original net."""
+    places = pn.get_places(names = False)
+    for p in places:
+        capacity = pn.vp_place_capacity[p]
+        if capacity <= 0:
+            continue # No capacity limit, no constraint
+        if p.in_degree() == 0:
+            continue # No input degree, this place cannot get new tokens
+
+        name = pn.vp_elem_name[p]
+        marking = pn.vp_place_initial_marking[p]
+
+        # QXXXXX will be the name of the place that constraints PXXXX
+        if name.startswith('P'):
+            qname = 'Q' + name[1:]
+        elif name.startswith('p'):
+            qname = 'q' + name[1:]
+        else:
+            qname = 'q_' + name
+
+        q = pn.add_place(qname)
+        pn.set_initial_marking(q, capacity - marking)
+        pn.set_capacity(q, capacity - marking)
+
+        for e in p.in_edges(): # Incoming edges
+            t = e.source()
+            if p in t.in_neighbours(): continue # Self-loop, skip it
+            pn.add_edge(q, t)
+
+        for e in p.out_edges():
+            t = e.target()
+            if p in t.out_neighbours(): continue # Self-loop, skip it
+            pn.add_edge(t, q)
+

--- a/pmlab/pn/replay.py
+++ b/pmlab/pn/replay.py
@@ -1,0 +1,65 @@
+import numpy as np
+from .. log import Log
+
+class UnfitLogError(Exception):
+    """This error is raised whenever there is a log that does not fit the model"""
+    pass
+
+def replay(pn, case):
+    """Simulates trace [case] in petri net [pn].
+    Note: this method invalidates the current marking of [pn].
+    If trace [case] is not covered by [pn], returns None.
+    Otherwise returns a 2-dimensional array where every row is a marking."""
+
+    places = pn.get_places(names = False)
+    trace = np.empty([1 + len(case), len(places)], dtype=np.int)
+
+    # Start from the initial marking
+    pn.to_initial_marking()
+    for i, p in enumerate(places):
+        trace[0, i] = pn.vp_current_marking[p]
+
+    for i, act in enumerate(case, start=1):
+        try:
+            t = pn.get_elem(act)
+        except KeyError:
+            return None
+        if not pn.is_transition_enabled(t):
+            return None
+        pn.fire_transition(t)
+        for j, p in enumerate(places):
+            trace[i, j] = pn.vp_current_marking[p]
+
+    return trace
+
+def fitness(pn, log):
+    """Returns the fitness of the given log with respect to net [pn]."""
+    num_cases = 0
+    num_fitting_cases = 0
+    for (case, reps) in log.get_uniq_cases().iteritems():
+        if replay(pn, case) is not None:
+            num_fitting_cases += reps
+        num_cases += reps
+
+    return num_fitting_cases / float(num_cases)
+
+def compute_capacity(pn, log):
+    """Compute the capacity of the places in [pn] that would be required to
+    replay all the traces from [log].
+    Modifies the capacities of [pn], but never decreases an existing capacity."""
+    places = pn.get_places(names = False)
+
+    curmax = np.empty([len(places)], dtype=np.int)
+    for i, p in enumerate(places):
+        curmax[i] = pn.vp_place_capacity[p]
+
+    for case in log.get_uniq_cases():
+        trace = replay(pn, case)
+        if trace is None:
+            raise UnfitLogError, case
+        tracemax = np.amax(trace, axis=0)
+        curmax = np.maximum(curmax, tracemax)
+
+    for i, p in enumerate(places):
+        pn.set_capacity(p, curmax[i])
+

--- a/pmlab/rapidprom/__init__.py
+++ b/pmlab/rapidprom/__init__.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+import os, os.path
+import subprocess
+import contextlib
+from tempfile import mkdtemp
+from shutil import rmtree
+from pmlab.pn import pn_from_file
+
+if 'MAX_JAVA_MEMORY' not in os.environ:
+	os.environ['MAX_JAVA_MEMORY'] = '4096'
+
+if 'JAVA_ADDITIONAL_OPTIONS' not in os.environ:
+	os.environ['JAVA_ADDITIONAL_OPTIONS'] = '-Djava.awt.headless=true'
+
+class RapidPromError(EnvironmentError):
+	pass
+
+@contextlib.contextmanager
+def _maketempdir(delete = False):
+    tempdir = mkdtemp()
+    yield tempdir
+    if delete:
+		rmtree(tempdir)
+
+def run_rapidminer_script(script, stdout, defs):
+	try:
+		rapidminer_home = os.environ['RAPIDMINER_HOME']
+	except KeyError:
+		raise EnvironmentError, "RAPIDMINER_HOME is not set"
+	rapidminer_bin = os.path.abspath(rapidminer_home + "/scripts/rapidminer")
+	script = os.path.abspath(os.path.join(os.path.dirname(__file__), script))
+	args = [rapidminer_bin, '-f', script]
+	for k, v in defs.iteritems():
+		args.append("-M%s=%s" % (k, v))
+	if stdout is not None:
+		out = open(stdout, 'w')
+	else:
+		out = None
+
+	exitcode = subprocess.call(args, stdout=out, stderr=out, cwd = rapidminer_home, close_fds = True)
+
+	if out is not None:
+		out.close()
+
+	if exitcode != 0:
+		raise RapidPromError
+
+def _run_miner_script(script, log, verbose=False):
+	with _maketempdir() as tmpdir:
+		stdout = None if verbose else os.path.join(tmpdir, "output.txt")
+		log_file = os.path.join(tmpdir, 'log.xes')
+		net_file = os.path.join(tmpdir, 'net.pnml')
+
+		log.save(log_file, format='xes')
+
+		run_rapidminer_script(script, stdout, {
+			'log_file': log_file,
+			'output_file': net_file
+		})
+
+		pn = pn_from_file(net_file, format='pnml')
+		pn.mark_as_modified(True) # We're about to delete its temporary file
+
+		return pn
+
+def mine_ilp(log, verbose=False):
+	return _run_miner_script('mine_ilp.rmp', log, verbose)
+
+def mine_inductive(log, verbose=False):
+	pn = _run_miner_script('inductive.rmp', log, verbose)
+	# Properly make "tau"s invisible:
+	for t in pn.get_transitions(names=False):
+		name = pn.vp_elem_name[t]
+		if name in ("tau from tree", "tau split") or name.startswith('start tau '):
+			pn.vp_transition_dummy[t] = True
+	return pn
+

--- a/pmlab/rapidprom/fitness.rmp
+++ b/pmlab/rapidprom/fitness.rmp
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="112" name="Multiply" width="90" x="45" y="120"/>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="246" y="75">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:read_pnml_file" compatibility="1.0.010" expanded="true" height="76" name="Read PNML File" width="90" x="246" y="210">
+        <parameter key="filename" value="%{pnml_file}"/>
+      </operator>
+      <operator activated="true" class="prom:alignetconformance" compatibility="1.0.010" expanded="true" height="112" name="Check Precision based on 1Align-ETConformance" width="90" x="447" y="120">
+        <parameter key="Max Explored States (in Hundreds)" value="100"/>
+      </operator>
+      <operator activated="true" class="write_csv" compatibility="5.3.015" expanded="true" height="76" name="Write CSV" width="90" x="581" y="75">
+        <parameter key="column_separator" value=";"/>
+        <parameter key="write_attribute_names" value="true"/>
+        <parameter key="quote_nominal_values" value="true"/>
+        <parameter key="format_date_attributes" value="true"/>
+        <parameter key="append_to_file" value="false"/>
+        <parameter key="encoding" value="SYSTEM"/>
+      </operator>
+      <operator activated="true" class="write_file" compatibility="5.3.015" expanded="true" height="60" name="Write File" width="90" x="715" y="75">
+        <parameter key="resource_type" value="file"/>
+        <parameter key="filename" value="%{output_file}"/>
+        <parameter key="mime_type" value="application/octet-stream"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="Read PNML File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="Check Precision based on 1Align-ETConformance" to_port="context (ProM Context)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="Check Precision based on 1Align-ETConformance" to_port="event log (ProM Event Log)"/>
+      <connect from_op="Read PNML File" from_port="model (ProM Petri Net)" to_op="Check Precision based on 1Align-ETConformance" to_port="model (ProM Petri Net)"/>
+      <connect from_op="Read PNML File" from_port="marking (ProM Marking)" to_op="Check Precision based on 1Align-ETConformance" to_port="marking (ProM Marking)"/>
+      <connect from_op="Check Precision based on 1Align-ETConformance" from_port="example set with metrics (Data Table)" to_op="Write CSV" to_port="input"/>
+      <connect from_op="Write CSV" from_port="file" to_op="Write File" to_port="file"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/inductive.rmp
+++ b/pmlab/rapidprom/inductive.rmp
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="112" name="Multiply" width="90" x="112" y="120"/>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="246" y="75">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:mine_petri_net_with_inductive_miner" compatibility="1.0.010" expanded="true" height="94" name="Mine Petri Net with Inductive Miner" width="90" x="380" y="120">
+        <parameter key="Define Inductive Miner" value="Mine Petri net with Inductive Miner - Infrequent"/>
+        <parameter key="Noise Threshold" value="0.0"/>
+        <parameter key="Incompleteness Threshold" value="1.0"/>
+      </operator>
+      <operator activated="true" class="prom:PNML_export" compatibility="1.0.010" expanded="true" height="94" name="PNML Export" width="90" x="514" y="255">
+        <parameter key="filename" value="%{output_file}"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="Mine Petri Net with Inductive Miner" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="PNML Export" to_port="context (ProM Context)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="Mine Petri Net with Inductive Miner" to_port="event log (ProM Event Log)"/>
+      <connect from_op="Mine Petri Net with Inductive Miner" from_port="model (ProM Petri Net)" to_op="PNML Export" to_port="model (ProM Petri Net)"/>
+      <connect from_op="Mine Petri Net with Inductive Miner" from_port="initial marking (ProM Marking)" to_op="PNML Export" to_port="marking (ProM Marking)"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/mine_ilp.rmp
+++ b/pmlab/rapidprom/mine_ilp.rmp
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="112" name="Multiply" width="90" x="179" y="30"/>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="313" y="30">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:ilp_miner" compatibility="1.0.010" expanded="true" height="76" name="ILP Miner" width="90" x="447" y="120">
+        <parameter key="Variant" value="PetriNetILPModel"/>
+      </operator>
+      <operator activated="true" class="prom:PNML_export" compatibility="1.0.010" expanded="true" height="94" name="PNML Export" width="90" x="581" y="210">
+        <parameter key="filename" value="%{output_file}"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="ILP Miner" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="PNML Export" to_port="context (ProM Context)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="ILP Miner" to_port="event log (ProM Event Log)"/>
+      <connect from_op="ILP Miner" from_port="model (ProM Petri Net)" to_op="PNML Export" to_port="model (ProM Petri Net)"/>
+      <connect from_op="ILP Miner" from_port="marking (ProM Marking)" to_op="PNML Export" to_port="marking (ProM Marking)"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/mine_ilp_sm.rmp
+++ b/pmlab/rapidprom/mine_ilp_sm.rmp
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="112" name="Multiply" width="90" x="179" y="30"/>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="313" y="30">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:ilp_miner" compatibility="1.0.010" expanded="true" height="76" name="ILP Miner" width="90" x="447" y="120">
+        <parameter key="Variant" value="PetriNetILPModel"/>
+        <parameter key="Mine for a state machine" value="true"/>
+      </operator>
+      <operator activated="true" class="prom:PNML_export" compatibility="1.0.010" expanded="true" height="94" name="PNML Export" width="90" x="581" y="210">
+        <parameter key="filename" value="%{output_file}"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="ILP Miner" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="PNML Export" to_port="context (ProM Context)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="ILP Miner" to_port="event log (ProM Event Log)"/>
+      <connect from_op="ILP Miner" from_port="model (ProM Petri Net)" to_op="PNML Export" to_port="model (ProM Petri Net)"/>
+      <connect from_op="ILP Miner" from_port="marking (ProM Marking)" to_op="PNML Export" to_port="marking (ProM Marking)"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/prec.rmp
+++ b/pmlab/rapidprom/prec.rmp
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="112" name="Multiply" width="90" x="45" y="120"/>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="246" y="75">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:read_pnml_file" compatibility="1.0.010" expanded="true" height="76" name="Read PNML File" width="90" x="246" y="210">
+        <parameter key="filename" value="%{pnml_file}"/>
+      </operator>
+      <operator activated="true" class="prom:alignetconformance" compatibility="1.0.010" expanded="true" height="112" name="Check Precision based on 1Align-ETConformance" width="90" x="447" y="120">
+        <parameter key="Max Explored States (in Hundreds)" value="100"/>
+      </operator>
+      <operator activated="true" class="write_csv" compatibility="5.3.015" expanded="true" height="76" name="Write CSV" width="90" x="581" y="75">
+        <parameter key="column_separator" value=";"/>
+        <parameter key="write_attribute_names" value="true"/>
+        <parameter key="quote_nominal_values" value="true"/>
+        <parameter key="format_date_attributes" value="true"/>
+        <parameter key="append_to_file" value="false"/>
+        <parameter key="encoding" value="SYSTEM"/>
+      </operator>
+      <operator activated="true" class="write_file" compatibility="5.3.015" expanded="true" height="60" name="Write File" width="90" x="715" y="75">
+        <parameter key="resource_type" value="file"/>
+        <parameter key="filename" value="%{output_file}"/>
+        <parameter key="mime_type" value="application/octet-stream"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="Read PNML File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="Check Precision based on 1Align-ETConformance" to_port="context (ProM Context)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="Check Precision based on 1Align-ETConformance" to_port="event log (ProM Event Log)"/>
+      <connect from_op="Read PNML File" from_port="model (ProM Petri Net)" to_op="Check Precision based on 1Align-ETConformance" to_port="model (ProM Petri Net)"/>
+      <connect from_op="Read PNML File" from_port="marking (ProM Marking)" to_op="Check Precision based on 1Align-ETConformance" to_port="marking (ProM Marking)"/>
+      <connect from_op="Check Precision based on 1Align-ETConformance" from_port="example set with metrics (Data Table)" to_op="Write CSV" to_port="input"/>
+      <connect from_op="Write CSV" from_port="file" to_op="Write File" to_port="file"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/simp_uma.rmp
+++ b/pmlab/rapidprom/simp_uma.rmp
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="130" name="Multiply" width="90" x="45" y="165"/>
+      <operator activated="true" class="prom:read_pnml_file" compatibility="1.0.010" expanded="true" height="76" name="Read PNML File" width="90" x="246" y="120">
+        <parameter key="filename" value="%{net_file}"/>
+      </operator>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="246" y="30">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:simplify_net" compatibility="1.0.010" expanded="true" height="112" name="simplify_net" width="90" x="514" y="75">
+        <parameter key="unfold and refold net" value="true"/>
+        <parameter key="filter branches &lt;" value="0.05"/>
+      </operator>
+      <operator activated="true" class="prom:PNML_export" compatibility="1.0.010" expanded="true" height="94" name="PNML Export" width="90" x="715" y="75">
+        <parameter key="filename" value="%{output_file}"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="Read PNML File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="simplify_net" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 4" to_op="PNML Export" to_port="context (ProM Context)"/>
+      <connect from_op="Read PNML File" from_port="model (ProM Petri Net)" to_op="simplify_net" to_port="model (ProM Petri Net)"/>
+      <connect from_op="Read PNML File" from_port="marking (ProM Marking)" to_op="simplify_net" to_port="marking (ProM Marking)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="simplify_net" to_port="event log (ProM Event Log)"/>
+      <connect from_op="simplify_net" from_port="model (ProM Petri Net)" to_op="PNML Export" to_port="model (ProM Petri Net)"/>
+      <connect from_op="simplify_net" from_port="marking (ProM Marking)" to_op="PNML Export" to_port="marking (ProM Marking)"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>

--- a/pmlab/rapidprom/simp_uma_th.rmp
+++ b/pmlab/rapidprom/simp_uma_th.rmp
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<process version="5.3.015">
+  <context>
+    <input/>
+    <output/>
+    <macros/>
+  </context>
+  <operator activated="true" class="process" compatibility="5.3.015" expanded="true" name="Process">
+    <parameter key="logverbosity" value="init"/>
+    <parameter key="random_seed" value="2001"/>
+    <parameter key="send_mail" value="never"/>
+    <parameter key="notification_email" value=""/>
+    <parameter key="process_duration_for_mail" value="30"/>
+    <parameter key="encoding" value="SYSTEM"/>
+    <process expanded="true">
+      <operator activated="true" class="prom:prom_context" compatibility="1.0.010" expanded="true" height="60" name="ProM Context" width="90" x="45" y="30"/>
+      <operator activated="true" class="multiply" compatibility="5.3.015" expanded="true" height="130" name="Multiply" width="90" x="45" y="165"/>
+      <operator activated="true" class="prom:read_pnml_file" compatibility="1.0.010" expanded="true" height="76" name="Read PNML File" width="90" x="246" y="120">
+        <parameter key="filename" value="%{net_file}"/>
+      </operator>
+      <operator activated="true" class="prom:read_log" compatibility="1.0.010" expanded="true" height="60" name="Read Log File" width="90" x="246" y="30">
+        <parameter key="Visualize Log" value="Visualize Log as ExampleSet"/>
+        <parameter key="filename" value="%{log_file}"/>
+        <parameter key="type of the log file" value="Naive"/>
+      </operator>
+      <operator activated="true" class="prom:simplify_net" compatibility="1.0.010" expanded="true" height="112" name="simplify_net" width="90" x="514" y="75">
+        <parameter key="unfold and refold net" value="true"/>
+        <parameter key="filter branches &lt;" value="%{threshold}"/>
+      </operator>
+      <operator activated="true" class="prom:PNML_export" compatibility="1.0.010" expanded="true" height="94" name="PNML Export" width="90" x="715" y="75">
+        <parameter key="filename" value="%{output_file}"/>
+      </operator>
+      <connect from_op="ProM Context" from_port="context (ProM Context)" to_op="Multiply" to_port="input"/>
+      <connect from_op="Multiply" from_port="output 1" to_op="Read Log File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 2" to_op="Read PNML File" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 3" to_op="simplify_net" to_port="context (ProM Context)"/>
+      <connect from_op="Multiply" from_port="output 4" to_op="PNML Export" to_port="context (ProM Context)"/>
+      <connect from_op="Read PNML File" from_port="model (ProM Petri Net)" to_op="simplify_net" to_port="model (ProM Petri Net)"/>
+      <connect from_op="Read PNML File" from_port="marking (ProM Marking)" to_op="simplify_net" to_port="marking (ProM Marking)"/>
+      <connect from_op="Read Log File" from_port="event log (ProM Event Log)" to_op="simplify_net" to_port="event log (ProM Event Log)"/>
+      <connect from_op="simplify_net" from_port="model (ProM Petri Net)" to_op="PNML Export" to_port="model (ProM Petri Net)"/>
+      <connect from_op="simplify_net" from_port="marking (ProM Marking)" to_op="PNML Export" to_port="marking (ProM Marking)"/>
+      <portSpacing port="source_input 1" spacing="0"/>
+      <portSpacing port="sink_result 1" spacing="0"/>
+    </process>
+  </operator>
+</process>


### PR DESCRIPTION
### New modules
- pn.bound: bounding PetriNets
- pn.replay: new functions for replaying traces in PetriNets
- rapidprom: running RapidProM scripts from python
### Fixes to pmlab modules
- AlphaReencoder with > 27 events: now generates a, b, c, d, ..., aa, ab, ...., ba, ..., aaa
- TransitionSystem: search log2ts, draw_astg in $PATH instead of hardcoding /usr/local/bin/...
- ts_from_sis, pn_from_sis: allow dots ('.') in identifiers; petrify allows this
- TransitionSystem.get_edge() fixed
- TransitionSystem.map_log_frequencies(): raise "UnfitTsError" if the TS does not model the log
- pn_from_sis: support sis files with implicit places
- pn_from_sis: raise exceptions for broken nets (e.g. with place->place arcs).
- pn_from_sis: allow loading PetriNets without initial marking
- pn_from_pnml: "be more liberal in what we accept" (to load nets from ProM)
- PetriNet.save_as_sis: clean up identifiers with invalid characters
- PetriNet.save_as_sis: export place capacities using ".capacity"
### Minor fixes (code style/documentation only)
- ts_from_sis: (use 'newlines' instead of 'Suppress(OneOrMore(LineEnd()))'
- TransitionSystem.set/get_initial_state: document the parameter/return value is the NAME of the state
- TransitionSystem.self_loop_labels: use "generator comprehensions" instead of lists
- TransitionSystem.follow_label: use the new method "find_output_edges"
- TransitionSystem.map_log_frequencies: use the new method "find_output_edges" instead of "follow_label"
- PetriNet.enabled_transitions: use the new method "is_transition_enabled"
### New features with no/minor API changes to existing modules
- log_from_xes: if filename.endswith('.gz') use gzip to automatically uncompress file
- TransitionSystem.save ('sis' format): like Petrify, print the number of states on the header as a comment
- TransitionSystem: add "remove_state" method (slow implementation!)
- TransitionSystem: add "remove_edge" method
- TransitionSystem: add "find_input/output_edges" methods 
- TransitionSystem.follow_label: return a Python iterable instead of a list
- ts_from_sis: allow loading from file objects too (to be consistent with other APIs)
- ts_from_pn: add a function to retrieve the TS from a PetriNet object
   Requires Petrify!
- PetriNet.is_transition_enabled: computes whether transition [t] is enabled in the current marking
- PetriNet.save_as_sis: same as PetriNet.save(file, format='sis')
- PetriNet.save_as_pnml: save as a ProM-compatible PNML file
- PetriNet.save: add new format parameter (to choose between 'sis' and 'pnml' and be consistent with other APIs)
- dummy transition support in PetriNet and TransitionSystem, including loading/saving
### BIG API changes
- log_ts.cases_included_in_ts: change signature of function
- pn_from_pnml: remove "+complete" suffix from transition names if loading from a PNML file
