### PR TITLE
fix a series of issues with recent graph tool versions

### DIFF
--- a/pmlab/__init__.py
+++ b/pmlab/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['log','ts']
+__all__ = ['log','ts','log_ts','pn','bpmn','cnet']

--- a/pmlab/pn/__init__.py
+++ b/pmlab/pn/__init__.py
@@ -643,6 +643,8 @@ class PetriNet:
         for t in self.get_transitions(names=False):
             assert t not in id_map
             name = self.vp_elem_name[t]
+            if self.vp_transition_dummy[t]:
+                name = '' # empty label for dummies
             xml_id = "n%d" % node_num
             node = xmltree.SubElement(page, '{http://www.pnml.org/version-2009/grammar/pnml}transition',
                 {'{http://www.pnml.org/version-2009/grammar/pnml}id': xml_id})

--- a/pmlab/pn/__init__.py
+++ b/pmlab/pn/__init__.py
@@ -286,7 +286,10 @@ class PetriNet:
         element name, then the corresponding element object (a vertex 
         representing either a place or a transition) is returned. If it is 
         already an object, the same object is returned."""
-        return self.name_to_elem[elem] if isinstance(elem,str) else elem
+        if isinstance(elem, str):
+            return self.g.vertex(self.name_to_elem[elem])
+        else:
+            return elem
 
     def add_transition(self, transition_name, dummy=False):
         """Adds the given transition to the graph, if not previously added. The 
@@ -297,7 +300,7 @@ class PetriNet:
         self.vp_elem_name[t] = transition_name
         self.vp_elem_type[t] = 'transition'
         self.vp_transition_dummy[t] = dummy
-        self.name_to_elem[transition_name] = t
+        self.name_to_elem[transition_name] = self.g.vertex_index[t]
         self.mark_as_modified()
         return t
     
@@ -309,7 +312,7 @@ class PetriNet:
         p = self.g.add_vertex()
         self.vp_elem_name[p] = place_name
         self.vp_elem_type[p] = 'place'
-        self.name_to_elem[place_name] = p
+        self.name_to_elem[place_name] = self.g.vertex_index[p]
         self.mark_as_modified()
         return p
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name = 'pmlab',
     description = 'Process Mining suite',
     author = ['Marc Sole','Josep Carmona'],
     author_email = 'jcarmona@lsi.upc.edu',
-    packages = ['pmlab','pmlab.log','pmlab.ts','pmlab.pn','pmlab.cnet','pmlab.bpmn','pmlab.scripts','pmlab.rapidprom'],
+    packages = ['pmlab','pmlab.log','pmlab.ts','pmlab.pn','pmlab.log_ts','pmlab.cnet','pmlab.bpmn','pmlab.scripts','pmlab.rapidprom'],
     package_data = {
         'pmlab.bpmn':['graphics/*.eps','graphics/*.gif'], #include figures
         'pmlab.rapidprom':['*.rmp'], 


### PR DESCRIPTION
This series of patches fix some bugs (no new features):

*  running setup.py install did not install the pmlab.log_ts module (which contains some functions to mine transition systems from logs).
* importing pmlab.* did not import the log_ts module nor many others
* cannot pickle TransitionSystem or PetriNet instances (and therefore cannot use e.g. python multiprocessing) because some maps were storing graph_tool Vertex objects. Fix by storing vertex indices, which do not change either.
* when writing a pnml file, ensure dummy transitions have no name; this will ensure they appear as silent transitions in many importers.